### PR TITLE
Refactor: Remove hardcoded secrets from the codebase

### DIFF
--- a/config/freesurfer_license_oficial.txt
+++ b/config/freesurfer_license_oficial.txt
@@ -1,5 +1,0 @@
-sales.raphael@mail.uft.edu.br
-83584
-*CdELcs2Rp8Dc
-FS/wBjmHnhHRY
-Uwtkxx9KvPqqPryOqzl/PpW1doYMVO3YS3TbLI1Sgg3/581J6KfPQdkhUM2UJmTM 

--- a/freesurfer_license.txt
+++ b/freesurfer_license.txt
@@ -1,7 +1,22 @@
-# FreeSurfer License - Para uso acadêmico/pesquisa
-# Registre-se em: https://surfer.nmr.mgh.harvard.edu/registration.html
-# Este é um placeholder - substitua pela sua licença real
-raphael.comaisserveria@email.com
-12345
-*Ca123456789
-FSabcdefghijk
+# TEMPLATE DE LICENÇA FREESURFER
+#
+# INSTRUÇÕES:
+# 1. Registre-se em: https://surfer.nmr.mgh.harvard.edu/registration.html
+# 2. Copie este arquivo para "freesurfer_license.txt"
+# 3. Substitua os campos abaixo pelos seus dados reais
+# 4. NUNCA commite o arquivo real no Git!
+#
+# FORMATO DA LICENÇA:
+# Linha 1: Seu email institucional
+# Linha 2: Número da licença
+# Linha 3: Chave de validação (começa com *)
+# Linha 4: Hash de verificação (começa com FS)
+
+SEU_EMAIL@INSTITUICAO.EDU
+XXXXX
+*CaXXXXXXXXX
+FSxxxxxxxxxxx
+
+# NOTA DE SEGURANÇA:
+# Este é apenas um template. Nunca compartilhe sua licença real!
+# O arquivo freesurfer_license.txt está no .gitignore por segurança.

--- a/freesurfer_license_oficial.txt
+++ b/freesurfer_license_oficial.txt
@@ -1,5 +1,0 @@
-sales.raphael@mail.uft.edu.br
-83584
-*CdELcs2Rp8Dc
-FS/wBjmHnhHRY
-Uwtkxx9KvPqqPryOqzl/PpW1doYMVO3YS3TbLI1Sgg3/581J6KfPQdkhUM2UJmTM 

--- a/run_fastsurfer_fixed.sh
+++ b/run_fastsurfer_fixed.sh
@@ -29,10 +29,10 @@ XXXXX
 *CaXXXXXXXXX
 FSxxxxxxxxxxx
 =======
-raphael.comaisserveria@email.com
-12345
-*Ca123456789
-FSabcdefghijk
+user@example.com
+XXXXX
+*CaXXXXXXXXX
+FSxxxxxxxxxxx
 >>>>>>> 3f8bd3ee87 (Add new processing scripts and documentation)
 EOF
     fi

--- a/test_fastsurfer_fixed.sh
+++ b/test_fastsurfer_fixed.sh
@@ -62,10 +62,10 @@ else
     LICENSE_FILE="$HOME/license.txt"
 =======
 # Este é um placeholder - substitua pela sua licença real
-raphael.comaisserveria@email.com
-12345
-*Ca123456789
-FSabcdefghijk
+user@example.com
+XXXXX
+*CaXXXXXXXXX
+FSxxxxxxxxxxx
 EOF
     echo "⚠️  ATENÇÃO: Licença temporária criada. Registre-se no FreeSurfer para licença oficial!"
 else


### PR DESCRIPTION
This commit removes hardcoded FreeSurfer license keys and email addresses from the repository to improve security.

The following changes were made:
- Deleted `freesurfer_license_oficial.txt` and `config/freesurfer_license_oficial.txt` which contained what appeared to be real license keys.
- Replaced the content of `freesurfer_license.txt` with the content of `freesurfer_license_template.txt` to remove a hardcoded email address.
- Replaced hardcoded email addresses in `test_fastsurfer_fixed.sh` and `run_fastsurfer_fixed.sh` with a placeholder.